### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Import this project into Android Studio... it's built with it.
 #### Gradle
 
 ```
-compile 'com.roger.catloadinglibrary:catloadinglibrary:1.0.4'
+implementation 'com.roger.catloadinglibrary:catloadinglibrary:1.0.4'
 ```
 
 ####  config in java code


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.