### PR TITLE
Change this fix problem with loading text

### DIFF
--- a/catloadinglibrary/src/main/java/com/roger/catloadinglibrary/GraduallyTextView.java
+++ b/catloadinglibrary/src/main/java/com/roger/catloadinglibrary/GraduallyTextView.java
@@ -141,7 +141,7 @@ public class GraduallyTextView extends EditText {
                 canvas.drawText(String.valueOf(text.charAt(lastOne)), 0, 1,
                         scaleX + getPaint().measureText(
                                 text.subSequence(0, lastOne).toString()),
-                        startY, mPaint);
+                        getHeight()/2, mPaint);
             }
         }
     }


### PR DESCRIPTION
The loading text is shown cut on bottom in Redmi 5s device. It is because startY is hard coded in this file. I propose this change to fix this. After this change it is working fine.